### PR TITLE
Adding ItemSafeEvent to this branch as well.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.biggestnerd.devotedpvp</groupId>
 	<artifactId>DevotedPvP</artifactId>
-	<version>1.2.2</version>
+	<version>1.2.3</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/com/biggestnerd/devotedpvp/ItemSafeEvent.java
+++ b/src/main/java/com/biggestnerd/devotedpvp/ItemSafeEvent.java
@@ -1,0 +1,37 @@
+package com.biggestnerd.devotedpvp;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+public class ItemSafeEvent extends Event {
+	private static final HandlerList handlers = new HandlerList();
+
+	private boolean valid;
+	private final ItemStack item;
+
+	public ItemSafeEvent(final ItemStack item) {
+		this.valid = false;
+		this.item = item;
+	}
+
+	public ItemStack getItem() {
+		return item;
+	}
+
+	public void setValid() {
+		this.valid = true;
+	}
+
+	public boolean isValid() {
+		return this.valid;
+	}
+
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+}

--- a/src/main/java/com/biggestnerd/devotedpvp/manager/InventoryManager.java
+++ b/src/main/java/com/biggestnerd/devotedpvp/manager/InventoryManager.java
@@ -2,6 +2,7 @@ package com.biggestnerd.devotedpvp.manager;
 
 import com.biggestnerd.devotedpvp.DevotedPvP;
 import com.biggestnerd.devotedpvp.PvPDao;
+import com.biggestnerd.devotedpvp.ItemSafeEvent;
 import com.biggestnerd.devotedpvp.model.PvPInventory;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,6 +15,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.Bukkit;
 
 public class InventoryManager {
 
@@ -33,6 +35,11 @@ public class InventoryManager {
 				ItemStack item = inventory.getItem(i);
 				if (item == null)
 					continue;
+				// Allow external plugins to vouch for an item.
+				ItemSafeEvent event = new ItemSafeEvent(item);
+				Bukkit.getServer().getPluginManager().callEvent(event);
+				if (event.isValid()) continue;
+				// done vouch.
 				if (Material.BEDROCK.equals(item.getType()) || Material.BARRIER.equals(item.getType())
 						|| Material.DRAGON_EGG.equals(item.getType()) || Material.END_CRYSTAL.equals(item.getType())
 						|| Material.END_GATEWAY.equals(item.getType()) || Material.ENDER_PORTAL.equals(item.getType())


### PR DESCRIPTION
Allows external plugins (like AddGun) to "validate" inventory items, and bypass cleansing.