### PR TITLE
Allow disabling inventory cleaning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.biggestnerd.devotedpvp</groupId>
 	<artifactId>DevotedPvP</artifactId>
-	<version>1.2.5</version>
+	<version>1.2.6</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/com/biggestnerd/devotedpvp/ConfigManager.java
+++ b/src/main/java/com/biggestnerd/devotedpvp/ConfigManager.java
@@ -16,6 +16,7 @@ public class ConfigManager {
 	private World spawnWorld;
 	private PvPDao dao;
 	private List<String> spectatorPerms;
+	private boolean cleanInventories;
 
 	public ConfigManager(DevotedPvP plugin) {
 		this.plugin = plugin;
@@ -36,6 +37,13 @@ public class ConfigManager {
 	 */
 	public World getSpawnWorld() {
 		return spawnWorld;
+	}
+	
+	/**
+	 * @return Whether saved inventories should be cleaned of unwanted NBT and unobtainable items
+	 */
+	public boolean shouldCleanInventories() {
+		return cleanInventories;
 	}
 
 	/**
@@ -61,6 +69,7 @@ public class ConfigManager {
 		dao = new PvPDao(plugin, username, password, host, port, dbname, 5, 1000L, 600000L, 7200000L);
 
 		spectatorPerms = config.getStringList("spectatorPerms");
+		cleanInventories = config.getBoolean("cleanInventories", true);
 
 	}
 

--- a/src/main/java/com/biggestnerd/devotedpvp/manager/InventoryManager.java
+++ b/src/main/java/com/biggestnerd/devotedpvp/manager/InventoryManager.java
@@ -25,6 +25,9 @@ public class InventoryManager {
 	 * Currently: * Stack Size * Enchantments * Potion effect * Eliminate exploit blocks (bedrock, dragon egg)
 	 */
 	public static boolean cleanInventory(Player player) {
+		if(!DevotedPvP.getInstance().getConfigManager().shouldCleanInventories()) {
+			return true;
+		}
 		try {
 			if (player == null)
 				return true;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,3 +21,6 @@ deathmessages:
   - RIP in pieces
   - Goodnight sweet prince
 # messages to show on death
+
+cleanInventories: true
+#whether to remove unwanted NBT etc. which can be obtained in gamemode 1


### PR DESCRIPTION
It removes additional NBT data, which some servers use to keep track of unique items